### PR TITLE
Specify edit_uri for mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: 'ATLAS Display API'
 site_description: 'Creating custom displays for McLaren ATLAS'
 docs_dir: 'docs'
 repo_url: https://github.com/mat-docs/ATLAS.DisplayAPI.Site
+edit_uri: edit/main/docs/
 site_url: https://docs.atlas.mclarenapplied.com/developer/atlas-displayapi/
 
 theme:


### PR DESCRIPTION
Required because default branch is not master.