### PR TITLE
Theme change to blue

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_url: https://docs.atlas.mclarenapplied.com/developer/atlas-displayapi/
 theme:
   name: 'material'
   palette:
-    primary:  'black'
+    primary:  'blue'
     accent:   'indigo'
   custom_dir: overrides
   # assets/swoosh is cached aggressively - rename if icons change


### PR DESCRIPTION
Make it visually distinct from the top-level portal for clearer navigation.

The portal uses a blue book icon next to the navigation link, to match.